### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=The DS1603L is an ultrasound water level sensor, which works from the 
 category=Sensors
 url=http://cityhydroponics.hk/
 architectures=*
-includes=
+includes=DS1603L.h
 


### PR DESCRIPTION
The includes field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > Arduino_DS1603L**. Leaving this field empty causes that action to add the following line to the sketch:
```
#include <>
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format